### PR TITLE
Compile fixes.

### DIFF
--- a/Thirdparty/DBoW2/DBoW2/FeatureVector.h
+++ b/Thirdparty/DBoW2/DBoW2/FeatureVector.h
@@ -22,7 +22,7 @@ class FeatureVector:
   public std::map<NodeId, std::vector<unsigned int> >
 {
 public:
-  typedef std::map<NodeId, std::vector<unsigned int>> super;
+  typedef std::map<NodeId, std::vector<unsigned int> > super;
   /**
    * Constructor
    */

--- a/include/BoostArchiver.h
+++ b/include/BoostArchiver.h
@@ -21,7 +21,7 @@
 #include <boost/serialization/split_free.hpp>
 #include <boost/serialization/base_object.hpp>
 // base object needed by DBoW2::BowVector and DBoW2::FeatureVector
-#include <opencv2/core.hpp>
+#include <opencv2/core/core.hpp>
 
 #include "Thirdparty/DBoW2/DBoW2/BowVector.h"
 #include "Thirdparty/DBoW2/DBoW2/FeatureVector.h"


### PR DESCRIPTION
Two small compile fixes.
1. BoW is changed to use '> >' in the template. This matches the existing code and makes the
compile work when it's not compiled with c++11

2. include/BoostArchiver amended to include the correct opencv2 library, matching the rest of the
code base).